### PR TITLE
Misc. editor_fixes typos

### DIFF
--- a/src/Gui/EditorView.cpp
+++ b/src/Gui/EditorView.cpp
@@ -1060,7 +1060,7 @@ void EditorViewWrapper::setFileName(const QString &fn)
     d->fileName = fn;
     // some editors need filename, for example PythonEditor
     // use Qt introspection to "textEdit->setFilename(fn)"
-    // does nothing if editor doesnt have this method
+    // does nothing if editor doesn't have this method
     QMetaObject::invokeMethod(d->textEdit, "setFileName",
                               Qt::DirectConnection, Q_ARG(QString, fn));
 }
@@ -1582,7 +1582,7 @@ void EditorSearchBar::foundCount(int foundOcurrences)
         m_searchEdit->setStyleSheet(QLatin1String(""));
 
     QString found = QString::number(foundOcurrences);
-    m_foundCountLabel->setText(tr("Found: %1 occurences").arg(found));
+    m_foundCountLabel->setText(tr("Found: %1 occurrences").arg(found));
 }
 
 void EditorSearchBar::searchChanged(const QString &str)

--- a/src/Gui/EditorView.h
+++ b/src/Gui/EditorView.h
@@ -128,7 +128,7 @@ Q_SIGNALS:
     void changeFileName(const QString &fileName);
 
     /**
-     * @brief switchedFile emitted when another file is shown in wiew
+     * @brief switchedFile emitted when another file is shown in view
      * for exapmle when we debug trace into another file
      */
     void switchedFile(const QString &fileName);

--- a/src/Gui/PythonCode.cpp
+++ b/src/Gui/PythonCode.cpp
@@ -402,7 +402,7 @@ void PythonSyntaxHighlighter::highlightBlock (const QString & text)
                         if (text.at(j) == QLatin1Char(' ')) {
                             ++count;
                         } else if (text.at(j) == QLatin1Char('\t')) {
-                            count += 8; // acording to python lexical documentaion tab is eight spaces
+                            count += 8; // according to python lexical documentaion tab is eight spaces
                         } else {
                             break;
                         }
@@ -673,7 +673,7 @@ void PythonSyntaxHighlighter::highlightBlock (const QString & text)
 
             int len = lastWordCh(i, text);
             if (d->activeBlock->indent() == 0)
-                // no intent, it cant be a method
+                // no intent, it can't be a method
                 setIdentifierBold(i, len, T_IdentifierFunction, SyntaxHighlighter::IdentifierFunction);
             else
                 setUndeterminedIdentifierBold(i, len, T_IdentifierDefUnknown, SyntaxHighlighter::IdentifierUnknown);
@@ -710,7 +710,7 @@ void PythonSyntaxHighlighter::highlightBlock (const QString & text)
 
             int len = lastWordCh(i, text);
             if (len < 1) {
-                if (ch == QLatin1Char('*')) // globs aren't a word char so they dont get caught
+                if (ch == QLatin1Char('*')) // globs aren't a word char so they don't get caught
                     len += 1;
                 else
                     break;
@@ -749,7 +749,7 @@ void PythonSyntaxHighlighter::highlightBlock (const QString & text)
         } // end switch
 
         prev = ch;
-        assert(i >= lastI); // else infinte loop
+        assert(i >= lastI); // else infinite loop
         lastI = i++;
 
     } // end loop
@@ -1805,7 +1805,7 @@ JediDefinition_list_t JediBaseDefinitionObj::goto_definitions() const
                                       <JediDefinition_list_t, JediDefinitionObj, JediDefinition_ptr_t>
                                                 (m_obj, "goto_definitions", nullptr, nullptr);
 
-    // questionable workaround, this function isnt public yet according to comment in code it seems be soon
+    // questionable workaround, this function isn't public yet according to comment in code it seems be soon
     if (!res.size())
         res = JediCommonP::fetchList
             <JediDefinition_list_t, JediDefinitionObj, JediDefinition_ptr_t>
@@ -2125,7 +2125,7 @@ Py::Object JediDebugProxy::proxy(const Py::Tuple &args)
         if (argsTuple.length() >= 2) {
             std::string color = Py::String(argsTuple[0]).as_std_string();
             std::string str = Py::String(argsTuple[1]).as_std_string();
-            // need to lock here if our recievers uses anything python in recieving slots
+            // need to lock here if our receivers uses anything python in receiving slots
             Base::PyGILStateLocker lock;
             Q_EMIT JediInterpreter::instance()->onDebugInfo(QString::fromStdString(color),
                                                             QString::fromStdString(str));
@@ -2309,7 +2309,7 @@ JediDefinition_list_t JediInterpreter::names(const QString source, const QString
 }
 
 // preload means that Jedi parsers them now instead of when detected in code
-// it doesnt import them to local env. if they are not C modules
+// it doesn't import them to local env. if they are not C modules
 bool JediInterpreter::preload_module(const QStringList modules) const
 {
     if (isValid()) {
@@ -2403,10 +2403,10 @@ void JediInterpreter::destroy()
 JediInterpreter::SwapIn::SwapIn() :
     m_oldState(nullptr)
 {
-    // ensure we dont re-swap and aquire lock (leads to deadlock)
+    // ensure we don't re-swap and acquire lock (leads to deadlock)
     if (!static_GILHeld) {
         static_GILHeld = true;
-        // aquire for global thread
+        // acquire for global thread
         m_GILState = PyGILState_Ensure();
         m_oldState = PyThreadState_Get();
 

--- a/src/Gui/PythonCode.h
+++ b/src/Gui/PythonCode.h
@@ -245,17 +245,17 @@ public:
 
     /**
      * @brief tokensBetweenOfType counts tokens ot type match between these positions
-     *         NOTE! this methos ignore T_Indent tokens
+     *         NOTE! this method ignores T_Indent tokens
      * @param startPos position to start at
      * @param endPos position where it should stop looking
-     * @param match against his token
+     * @param match against this token
      * @return number of times token was found
      */
     int tokensBetweenOfType(int startPos, int endPos, PythonSyntaxHighlighter::Tokens match) const;
 
     /**
      * @brief lastInserted gives the last inserted token
-     *         NOTE! this method ignore T_Indent tokens
+     *         NOTE! this method ignores T_Indent tokens
      * @param lookInPreviousRows if false limits to this textblock only
      * @return last inserted token or nullptr if empty
      */
@@ -354,7 +354,7 @@ private:
     QVector<int> m_undeterminedIndexes; // index to m_tokens where a undetermined is at
                                         //  (so context parser can detemine it later)
     QTextBlock m_block;
-    int m_indentCharCount; // as spaces NOTE according  to python documentation a tab is 8 spaces
+    int m_indentCharCount; // as spaces NOTE according to python documentation a tab is 8 spaces
 
     friend class PythonSyntaxHighlighter; // in order to hide some api
 };
@@ -362,7 +362,7 @@ private:
 // -----------------------------------------------------------------------
 
 /**
- * @brief The PythonMatchingChars highlights the oposite (), [] or {}
+ * @brief The PythonMatchingChars highlights the opposite (), [] or {}
  */
 class PythonMatchingChars : public QObject
 {

--- a/src/Gui/PythonDebugger.cpp
+++ b/src/Gui/PythonDebugger.cpp
@@ -42,10 +42,10 @@ using namespace Gui;
 Py::ExceptionInfo::SwapIn::SwapIn(PyThreadState *newState) :
     m_oldState(nullptr)
 {
-    // ensure we dont re-swap and aquire lock (leads to deadlock)
+    // ensure we don't re-swap and acquire lock (leads to deadlock)
     if (!static_GILHeld) {
         static_GILHeld = true;
-        // aquire for global thread
+        // acquire for global thread
         m_GILState = PyGILState_Ensure();
         m_oldState = PyThreadState_Get();
 
@@ -233,7 +233,7 @@ QString Py::ExceptionInfo::message() const
         }
     }
     if (!vlu)
-        return QString(); // unkown type
+        return QString(); // unknown type
 
     const char *msg = PyBytes_AS_STRING(vlu);
     Py_XDECREF(vlu);
@@ -475,7 +475,7 @@ BreakpointLine& BreakpointLine::operator=(const BreakpointLine& other)
 {
     m_condition = other.m_condition;
     m_lineNr = other.m_lineNr;
-    m_hitCount = 0; // dont copy hit counts
+    m_hitCount = 0; // don't copy hit counts
     m_ignoreTo = other.m_ignoreTo;
     m_ignoreFrom = other.m_ignoreFrom;
     m_disabled = other.m_disabled;
@@ -1610,7 +1610,7 @@ int PythonDebugger::tracer_callback(PyObject *obj, PyFrameObject *frame, int wha
         if (self->runtimeException &&
             self->runtimeException->threadState() == PyThreadState_GET())
         {
-            // if arg is set, no exception occured
+            // if arg is set, no exception occurred
             if (arg) {
                 // error has been cleared
                 delete self->runtimeException;

--- a/src/Gui/PythonDebugger.h
+++ b/src/Gui/PythonDebugger.h
@@ -351,7 +351,7 @@ public:
     /**
      * @brief changes currentFrame and emits signals
      * @param level 0 is to top/global
-     * @return true on sucess
+     * @return true on success
      */
     bool setStackLevel(int level);
 

--- a/src/Gui/PythonDebuggerView.cpp
+++ b/src/Gui/PythonDebuggerView.cpp
@@ -818,7 +818,7 @@ QVariant IssuesModel::data(const QModelIndex &index, int role) const
 
         QString srcText = exc->text();
         int offset = exc->offset();
-        if (offset > 0) { // syntax error and such that give a column where it occured
+        if (offset > 0) { // syntax error and such that give a column where it occurred
             if (!srcText.endsWith(QLatin1String("\n")))
                 srcText += QLatin1String("\n");
             for (int i = 0; i < offset -1; ++i) {
@@ -883,7 +883,7 @@ bool IssuesModel::removeRows(int row, int count, const QModelIndex &parent)
 
 void IssuesModel::exceptionOccured(const Py::ExceptionInfo *exc)
 {
-    // on runtime, we dont want to catch rentime exceptions before they are fatal
+    // on runtime, we don't want to catch runtime exceptions before they are fatal
     // but we do want to catch warnings
     //if (exc->isWarning())
         exception(exc);
@@ -970,7 +970,7 @@ void VariableTreeItem::addChild(VariableTreeItem *item)
         }
     }
 
-    // if we get here are definetly last
+    // if we get here are definitely last
     childItems.append(item);
 }
 
@@ -1384,7 +1384,7 @@ void VariableTreeModel::lazyLoad(const QModelIndex &parent)
 void VariableTreeModel::lazyLoad(VariableTreeItem *parentItem)
 {
     Py::Dict dict;
-    // workaround to not beeing able to store pointers to variables
+    // workaround to not being able to store pointers to variables
     QString myName = parentItem->name();
     Py::Object me = parentItem->parent()->getAttr(myName);
     if (me.isNull())
@@ -1463,13 +1463,13 @@ void VariableTreeModel::scanObject(PyObject *startObject, VariableTreeItem *pare
 
 
     // first we traverse and compare before we do anything so
-    // view dont get updated to many times
+    // view doesn't get updated too many times
 
     // traverse and compare
     for (Py::List::iterator it = keys.begin(); it != keys.end(); ++it) {
         Py::String key(*it);
         QString name = QString::fromStdString(key);
-        // PyCXX metods throws here on type objects from class self type?
+        // PyCXX methods throws here on type objects from class self type?
         // use Python C instead
         QString newValue, newType;
         PyObject *vl, *itm;
@@ -1477,14 +1477,14 @@ void VariableTreeModel::scanObject(PyObject *startObject, VariableTreeItem *pare
         if (itm) {
             Py_XINCREF(itm);
             if (PyCallable_Check(itm))
-                continue; // dont want to crowd explorer with functions
+                continue; // don't want to crowd explorer with functions
             vl = PyObject_Str(itm);
             if (vl) {
                 char *vlu = PyBytes_AS_STRING(vl);
                 newValue = QString(QLatin1String(vlu));
 
                 if (!PyBytes_Check(itm)) {
-                    // extract memory adress if needed, but not on ordinary strings
+                    // extract memory address if needed, but not on ordinary strings
                     QRegExp re(QLatin1String("^<\\w+[\\w\\s'\"\\.\\-]* at (?:0x)?([0-9a-fA-F]+)>$"));
                     if (re.indexIn(newValue) != -1) {
                         newValue = re.cap(1);
@@ -1554,7 +1554,7 @@ void VariableTreeModel::scanObject(PyObject *startObject, VariableTreeItem *pare
 
 
     // handle updates
-    // this tries to find out how many consecutive rows thats changed
+    // this tries to find out how many consecutive rows that've changed
     int row = 0;
     for (const QString &item : updated) {
         row = parentItem->childRowByName(item);
@@ -1575,7 +1575,7 @@ void VariableTreeModel::scanObject(PyObject *startObject, VariableTreeItem *pare
 
     // handle inserts
     // these are already created during compare phase
-    // we insert last so variables dont jump around in the treeview
+    // we insert last so variables don't jump around in the treeview
     if (added.size()) {
         QModelIndex parentIdx = createIndex(row, 0, parentItem);
         addRows(added, parentIdx);

--- a/src/Gui/PythonEditor.cpp
+++ b/src/Gui/PythonEditor.cpp
@@ -492,7 +492,7 @@ void PythonEditor::keyPressEvent(QKeyEvent * e)
             // add one because this Key adds a row
             afterLineNr += 1;
         } else if (cursor.atBlockEnd()) {
-            // dont move breakpoint if we are at line end
+            // don't move breakpoint if we are at line end
             beforeLineNr += 1;
             afterLineNr = beforeLineNr +1;
         }
@@ -1002,7 +1002,7 @@ void PythonEditor::onAutoIndent()
         QString txt = block.text();
         if (mayIndent && reNewBlock.indexIn(txt) > -1) {
             indentLevel.append(chrCount);
-            blockIndent = -1; // dont indent this row
+            blockIndent = -1; // don't indent this row
             if (mCommentChr != 0)
                 ++mCommentIndents;
         }
@@ -1147,7 +1147,7 @@ void PythonEditorCodeAnalyzer::OnChange(Base::Subject<const char *> &rCaller,
             d->isActive = JediInterpreter::instance()->isValid();
             if (!d->isActive) {
                 QMessageBox::warning(d->editor, tr("Python editor"),
-                                     tr("<h1>Jedi doesnt work!</h1>Are you sure it's installed correctly?"
+                                     tr("<h1>Jedi doesn't work!</h1>Are you sure it's installed correctly?"
                                         "<br/> &nbsp;&nbsp; run:<i><b>pip install jedi</b></i> on command line"
                                         "<br/><a href='https://pypi.python.org/pypi/jedi/'>https://pypi.python.org/pypi/jedi</a>"));
 
@@ -1310,7 +1310,7 @@ bool PythonEditorCodeAnalyzer::eventFilter(QObject *obj, QEvent *event)
         return true;
 
     if  (obj == d->editor) {
-        // Ot doesnt let me snatch keypress originating from Completer
+        // Qt doesn't let me snatch keypress originating from Completer
         if (event->type() == QEvent::KeyPress) {
             QKeyEvent *e = static_cast<QKeyEvent*>(event);
             if (e->text().isEmpty() && e->modifiers() & (Qt::ShiftModifier | Qt::ControlModifier))
@@ -1343,7 +1343,7 @@ bool PythonEditorCodeAnalyzer::keyPressed(QKeyEvent *e)
 
     bool bailout = false;
 
-    // do nothing if ctrl or shift on ther own
+    // do nothing if ctrl or shift on their own
     if (!forcePopup && (e->modifiers() & (Qt::ShiftModifier | Qt::ControlModifier)) &&
         e->text().isEmpty())
         bailout = true;
@@ -1410,7 +1410,7 @@ bool PythonEditorCodeAnalyzer::keyPressed(QKeyEvent *e)
 
         d->taskAfterReparse = d->Both;
 
-        d->parseTimer.start(d->parseTimeoutMs); // user wont notice 50msec delay, but makes a lot of
+        d->parseTimer.start(d->parseTimeoutMs); // user won't notice 50msec delay, but makes a lot of
                                  // difference on machine strain
 
     } else {
@@ -1454,7 +1454,7 @@ void PythonEditorCodeAnalyzer::popupChoiceHighlighted(const QModelIndex &idx)
     QPoint pos = d->editor->completer()->popup()->pos();
     pos.rx() += d->editor->completer()->popup()->width();
 
-    // for debug only, popup lock out all events so we cant debug
+    // for debug only, popup lock out all events so we can't debug
     //d->editor->completer()->popup()->hide();
 
     QToolTip::showText(pos, buildToolTipText(def), d->editor->completer()->popup());
@@ -1466,9 +1466,9 @@ bool PythonEditorCodeAnalyzer::afterChoiceInserted(JediBaseDefinitionObj *obj, i
         return false;
 
     QString type = obj->type();
-    bool paranthesis = false;
+    bool parenthesis = false;
     if (type == QLatin1String("function") || type == QLatin1String("class")) {
-        paranthesis = true;
+        parenthesis = true;
 
     } else if(type == QLatin1String("statement")) {
         JediDefinition_list_t lookups;
@@ -1481,13 +1481,13 @@ bool PythonEditorCodeAnalyzer::afterChoiceInserted(JediBaseDefinitionObj *obj, i
         // take last, hopefully last assignment
         for (JediBaseDefinition_ptr_t lookObj : lookups)
         {
-            if (lookObj->type() != QLatin1String("statment")) {
+            if (lookObj->type() != QLatin1String("statement")) {
                 return afterChoiceInserted(lookObj.get(), ++recursionGuard);
             }
         }
     }
 
-    if (paranthesis) {
+    if (parenthesis) {
         QTextCursor cursor(d->editor->textCursor());
         cursor.insertText(QLatin1String("()"));
         cursor.movePosition(QTextCursor::Left);
@@ -2079,7 +2079,7 @@ void PythonCallSignatureWidget::resetList()
     d->signatures = d->analyzer->currentScriptObj()->call_signatures();
 
     if (d->signatures.size()) {
-        // store these for later comparisson, so we dont open on another function call
+        // store these for later comparison, so we don't open on another function call
         d->functionName = d->signatures[0]->name();
         d->lineNr = d->analyzer->editor()->textCursor().block().blockNumber();
     }

--- a/src/Gui/PythonEditor.h
+++ b/src/Gui/PythonEditor.h
@@ -226,7 +226,7 @@ private:
 // ------------------------------------------------------------
 
 /**
- * @breif displays arguments to functions
+ * @brief displays arguments to functions
  * and other usages to this function
  */
 class PythonCallSignatureWidgetP;

--- a/src/Gui/SyntaxHighlighter.cpp
+++ b/src/Gui/SyntaxHighlighter.cpp
@@ -214,7 +214,7 @@ public:
 
 
         // aliases, only show the more detailed name in editor settings
-        // keys inserted here wont show up in editor settings dialog
+        // keys inserted here won't show up in editor settings dialog
         aliased << QLatin1String("String")     << QLatin1String("BlockComment")
                 << QLatin1String("Class name") << QLatin1String("Define name");
     }
@@ -349,8 +349,8 @@ void SyntaxHighlighter::colorChanged(const QString& type, const QColor& col)
 
 int SyntaxHighlighter::maximumUserState() const
 {
-    // used in python console so we dont copy python errors and python output
-    // when issueing "Copy command"
+    // used in python console so we don't copy python errors and python output
+    // when issuing "Copy command"
     // also in PythonSyntaxHighLighter to set state on textBlock from previous block
     return static_cast<int>(PythonConsoleOutput) -1;
 }

--- a/src/Gui/TextEdit.h
+++ b/src/Gui/TextEdit.h
@@ -159,7 +159,7 @@ private:
 
 class AnnotatedScrollBarP;
 /**
- * @breif A custom scrollbar that can show markers at different lines
+ * @brief A custom scrollbar that can show markers at different lines
  *      such as markers when searching for a word
  */
 class AnnotatedScrollBar : public QScrollBar


### PR DESCRIPTION
Most of these are trivial comment typos. but some are doxy and even variables (i usually don't fix these bug i searched and found that in certain cases i could) that were misspelled.
Remaining 2 typos I didn't know what to do about:
```
$ codespell -d -q 3 --skip="*.po,*.ts"
./PythonDebuggerView.cpp:465: dont  ==> don't
./PythonCode.h:247: ot  ==> to
```